### PR TITLE
[BUGFIX] Synchronize CUDA context before force copying

### DIFF
--- a/platforms/cuda/src/CudaTorchKernels.cpp
+++ b/platforms/cuda/src/CudaTorchKernels.cpp
@@ -90,6 +90,8 @@ double CudaCalcTorchForceKernel::execute(ContextImpl& context, bool includeForce
     vector<torch::jit::IValue> inputs = {posTensor};
     if (usePeriodic)
         inputs.push_back(boxTensor);
+    // synchronizing the current context before switching to PyTorch
+    CHECK_RESULT(cuCtxSynchronize(), "Error synchronizing CUDA context");
     torch::Tensor energyTensor = module.forward(inputs).toTensor();
     if (includeForces) {
         energyTensor.backward();


### PR DESCRIPTION
Pull request for fixing a bug due to CUDA synchronizing issues in the current code base.

### Bug Description
During our application of this plugin on a system with 350 particles for incorporating a neural network force (on CUDA platform), there is a strange behavior similar to the description of Issue #13, i.e., the average temperature is lower under the Langevin thermostat setting.

The output force from the plugin is sometimes correct, but most of the time very wrong (it has less than half of the expected magnitude) comparing to a direct evaluation of the neural network in PyTorch.

### Diagnosis

Pull #15 and #16 do not solve the problem on our side.

Line 85 of `platforms/cuda/src/CudaTorchKernels.cpp`: `energyTensor.backward()` *seems* async (at least for PyTorch version 1.5), although there's no proper description in the [official documents for C++ API](https://pytorch.org/cppdocs/api/classat_1_1_tensor.html?highlight=tensor#_CPPv4NK2at6Tensor8backwardERKN3c108optionalI6TensorEEN3c108optionalIbEEb).
Line 87 of `platforms/cuda/src/CudaTorchKernels.cpp`: `posTensor.grad()[.clone()]` returns (a reference of) the grad tensor without blocking until gradient calculation is actually finished.
Therefore, I suspect that the neural network operations is not properly finished.
Note that in the Python [documentation](https://pytorch.org/docs/stable/notes/cuda.html#asynchronous-execution), they do say that PyTorch operations on CUDA are **asynchronous**.

### Bug Fix
Synchronize with GPU before changing the CUDA context or executing the `addForceKernel`, so as to make sure that all operations on (Py)Torch side is complete.
However, somehow the C++ API itself doesn't expose an equivalent to [`torch.cuda.synchronize()`](https://pytorch.org/docs/stable/cuda.html#torch.cuda.synchronize) (at least according to their documentation).
I propose to call an equivalent function directly from the CUDA runtime APIs instead, which is used inside [some other code](https://github.com/pytorch/pytorch/blob/4aca63d38aaed749a72b31eab098f7305ea711f4/test/cpp/tensorexpr/test_cuda.cpp#L74) of PyTorch itself.
Current solution solves our problem.