### PR TITLE
Move the PyTorch module to a correct device

### DIFF
--- a/platforms/cuda/src/CudaTorchKernels.cpp
+++ b/platforms/cuda/src/CudaTorchKernels.cpp
@@ -61,7 +61,7 @@ void CudaCalcTorchForceKernel::initialize(const System& system, const TorchForce
     int numParticles = system.getNumParticles();
 
     // Initialize CUDA objects for PyTorch
-    torch::Device device(torch::kCUDA, cu.getDeviceIndex()); // This implicitly initialize PyTorch
+    const torch::Device device(torch::kCUDA, cu.getDeviceIndex()); // This implicitly initialize PyTorch
     module.to(device);
     torch::TensorOptions options = torch::TensorOptions()
         .device(device)

--- a/platforms/cuda/src/CudaTorchKernels.cpp
+++ b/platforms/cuda/src/CudaTorchKernels.cpp
@@ -61,10 +61,11 @@ void CudaCalcTorchForceKernel::initialize(const System& system, const TorchForce
     int numParticles = system.getNumParticles();
 
     // Initialize CUDA objects for PyTorch
-    module.to(torch::kCUDA); // This implicitly initialize PyTorch
+    torch::Device device(torch::kCUDA, cu.getDeviceIndex()); // This implicitly initialize PyTorch
+    module.to(device);
     torch::TensorOptions options = torch::TensorOptions()
-            .device(torch::kCUDA, cu.getDeviceIndex())
-            .dtype(cu.getUseDoublePrecision() ? torch::kFloat64 : torch::kFloat32);
+        .device(device)
+        .dtype(cu.getUseDoublePrecision() ? torch::kFloat64 : torch::kFloat32);
     posTensor = torch::empty({numParticles, 3}, options.requires_grad(!outputsForces));
     boxTensor = torch::empty({3, 3}, options);
 

--- a/python/tests/TestTorchForce.py
+++ b/python/tests/TestTorchForce.py
@@ -51,9 +51,10 @@ def testModuleArguments(deviceString, precision):
             super().__init__()
             self.device = device
             self.dtype = dtype
-            self.positions = pt.tensor(positions).to(self.device).to(self.dtype)
+            self.register_buffer('positions', pt.tensor(positions).to(dtype))
 
         def forward(self, positions):
+            assert self.positions.device == self.device
             assert positions.device == self.device
             assert positions.dtype == self.dtype
             assert pt.all(positions == self.positions)


### PR DESCRIPTION
On a multi-GPU system, the Pytorch module should be moved to a selected device, but it was always moved to `cuda:0`.

- [x] Move the module to a correct device
- [x] Add a test