### PR TITLE
Push primary context before invoking PyTorch

### DIFF
--- a/platforms/cuda/src/CudaTorchKernels.cpp
+++ b/platforms/cuda/src/CudaTorchKernels.cpp
@@ -78,6 +78,9 @@ void CudaCalcTorchForceKernel::initialize(const System& system, const TorchForce
 }
 
 double CudaCalcTorchForceKernel::execute(ContextImpl& context, bool includeForces, bool includeEnergy) {
+    CUcontext primary;
+    cuDevicePrimaryCtxRetain(&primary, cu.getDevice());
+    cuCtxPushCurrent(primary);
     int numParticles = cu.getNumAtoms();
 
     // Get pointers to the atomic positions and simulation box
@@ -154,5 +157,7 @@ double CudaCalcTorchForceKernel::execute(ContextImpl& context, bool includeForce
         if (!outputsForces)
             posTensor.grad().zero_();
     }
+    cuCtxPopCurrent(&primary);
+    cuDevicePrimaryCtxRelease(cu.getDevice());
     return energyTensor.item<double>(); // This implicitly synchronize the PyTorch context
 }


### PR DESCRIPTION
Fixes https://github.com/openmm/openmm/issues/3588.

It seems that the CUDA runtime API, which PyTorch uses, doesn't play well with the stack of CUDA contexts.  When you invoke a PyTorch function, it expects the primary context to already be current.  If it isn't, then things often still work but sometimes fail with obscure errors.  This change ensures the primary context will be current.

@Hong-Rui can you test this and verify it works for you?

@dominicrufa I suspect this may also resolve https://github.com/openmm/openmm-ml/issues/32.  Can you try it out and see?