### PR TITLE
Revert "Push primary context before invoking PyTorch"

### DIFF
--- a/platforms/cuda/src/CudaTorchKernels.cpp
+++ b/platforms/cuda/src/CudaTorchKernels.cpp
@@ -78,9 +78,6 @@ void CudaCalcTorchForceKernel::initialize(const System& system, const TorchForce
 }
 
 double CudaCalcTorchForceKernel::execute(ContextImpl& context, bool includeForces, bool includeEnergy) {
-    CUcontext primary;
-    cuDevicePrimaryCtxRetain(&primary, cu.getDevice());
-    cuCtxPushCurrent(primary);
     int numParticles = cu.getNumAtoms();
 
     // Get pointers to the atomic positions and simulation box
@@ -157,7 +154,5 @@ double CudaCalcTorchForceKernel::execute(ContextImpl& context, bool includeForce
         if (!outputsForces)
             posTensor.grad().zero_();
     }
-    cuCtxPopCurrent(&primary);
-    cuDevicePrimaryCtxRelease(cu.getDevice());
     return energyTensor.item<double>(); // This implicitly synchronize the PyTorch context
 }


### PR DESCRIPTION
Reverts openmm/openmm-torch#78
- A proper review process wasn't followed: https://github.com/openmm/openmm-torch/pull/78#issuecomment-1156272190
- A few issue need to be resolved: https://github.com/openmm/openmm-torch/pull/78#issuecomment-1156499624