### PR TITLE
Pin swig to <4.1

### DIFF
--- a/devtools/conda-envs/build-macos-11.yml
+++ b/devtools/conda-envs/build-macos-11.yml
@@ -12,4 +12,4 @@ dependencies:
   - pytest
   - python
   - pytorch-cpu @PYTORCH_VERSION@
-  - swig
+  - swig <4.1

--- a/devtools/conda-envs/build-ubuntu-18.04.yml
+++ b/devtools/conda-envs/build-ubuntu-18.04.yml
@@ -15,6 +15,6 @@ dependencies:
   - pytest
   - python
   - pytorch-gpu @PYTORCH_VERSION@
-  - swig
+  - swig <4.1
   - sysroot_linux-64 2.17
   - torchani


### PR DESCRIPTION
- [x] Pin `swig` to <4.1

`swig` 4.1.0 fails with the following error:
```
/usr/share/miniconda3/envs/build/include/swig/OpenMMSwigHeaders.i:12: Error: Unknown directive '%factory'.
```