### PR TITLE
Clone the module on TorchForceImpl initialization

### DIFF
--- a/openmmapi/src/TorchForceImpl.cpp
+++ b/openmmapi/src/TorchForceImpl.cpp
@@ -46,7 +46,7 @@ TorchForceImpl::~TorchForceImpl() {
 }
 
 void TorchForceImpl::initialize(ContextImpl& context) {
-    auto module = owner.getModule();
+    auto module = owner.getModule().clone();
     // Create the kernel.
     kernel = context.getPlatform().createKernel(CalcTorchForceKernel::Name(), context);
     kernel.getAs<CalcTorchForceKernel>().initialize(context.getSystem(), owner, module);


### PR DESCRIPTION
This avoids different contexts sharing the same instance of the module owned by TorchForce.
Fixes https://github.com/openmm/NNPOps/pull/113 and https://github.com/openmm/NNPOps/issues/112 