### PR TITLE
Fix automatic CUDA graphing not working when requiring backwards

### DIFF
--- a/platforms/cuda/src/CudaTorchKernels.cpp
+++ b/platforms/cuda/src/CudaTorchKernels.cpp
@@ -188,7 +188,9 @@ static void executeGraph(bool outputsForces, bool includeForces, torch::jit::scr
         energyTensor = module.forward(inputs).toTensor();
         // Compute force by backpropagating the PyTorch model
         if (includeForces) {
-            energyTensor.backward();
+	    auto None = torch::Tensor();
+	    energyTensor.backward(None, false, false, posTensor);
+	    // This is minus the forces, we change the sign later on
             forceTensor = posTensor.grad().clone();
             // Zero the gradient to avoid accumulating it
             posTensor.grad().zero_();

--- a/platforms/cuda/src/CudaTorchKernels.cpp
+++ b/platforms/cuda/src/CudaTorchKernels.cpp
@@ -188,8 +188,10 @@ static void executeGraph(bool outputsForces, bool includeForces, torch::jit::scr
         energyTensor = module.forward(inputs).toTensor();
         // Compute force by backpropagating the PyTorch model
         if (includeForces) {
-	    auto None = torch::Tensor();
-	    energyTensor.backward(None, false, false, posTensor);
+            // CUDA graph capture sometimes fails if backwards is not explicitly requested w.r.t positions
+	    // See https://github.com/openmm/openmm-torch/pull/120/
+	    auto none = torch::Tensor();
+	    energyTensor.backward(none, false, false, posTensor);
 	    // This is minus the forces, we change the sign later on
             forceTensor = posTensor.grad().clone();
             // Zero the gradient to avoid accumulating it


### PR DESCRIPTION
CUDA was complaining about computing the forces via backpropagation of the energies with some modules when trying to use CUDA graphs.
I was able to fix this by instructing backwards to do the gradient of the energy only with respect to the positions.
Allow the example below (provided by @raimis to run)
```python
from openmm import System, VerletIntegrator, Platform, Context
from openmmtorch import TorchForce
from torchmdnet.models.model import create_model
import torch as pt

args = {"model": "tensornet",
        "embedding_dimension": 128,
        "num_layers": 2,
        "num_rbf": 32,
        "rbf_type": "expnorm",
        "trainable_rbf": False,
        "activation": "silu",
        "cutoff_lower": 0.0,
        "cutoff_upper": 5.0,
        "max_z": 100,
        "max_num_neighbors": 128,
        "equivariance_invariance_group": "O(3)",
        "prior_model": None,
        "atom_filter": -1,
        "derivative": False,
        "output_model": "Scalar",
        "reduce_op": "sum",
        "precision": 32 }
model = create_model(args)
class Model(pt.nn.Module):

    def __init__(self, model, zs):
        super().__init__()
        self.model = model
        self.register_buffer("zs", pt.tensor(zs, dtype=pt.long))

    def forward(self, pos):
        return self.model(self.zs, pos)[0]

model2 = pt.jit.script(Model(model, [1, 1]).to("cuda")).to("cuda")
force = TorchForce(model2, {"useCUDAGraphs": "true", "CUDAGraphWarmupSteps": "1"})

system = System()
for _ in range(2):
    system.addParticle(1)
system.addForce(force)
context = Context(system, VerletIntegrator(1), Platform.getPlatformByName("CUDA"))

context.setPositions([[0, 0, 0], [1, 0, 0]])
print(context.getState(getForces=True).getForces())
```
