### PR TITLE
Support parameter derivatives

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -77,6 +77,53 @@ jobs:
           NVCC_VERSION: ${{ matrix.nvcc-version }}
           PYTORCH_VERSION: ${{ matrix.pytorch-version }}
 
+      - name: Manage disk space
+        if: matrix.os == 'ubuntu'
+        run: |
+          sudo mkdir -p /opt/empty_dir || true
+          for d in \
+                   /opt/ghc \
+                   /opt/hostedtoolcache \
+                   /usr/lib/jvm \
+                   /usr/local/.ghcup \
+                   /usr/local/lib/android \
+                   /usr/local/share/powershell \
+                   /usr/share/dotnet \
+                   /usr/share/swift \
+                   ; do
+            sudo rsync --stats -a --delete /opt/empty_dir/ $d || true
+          done
+          sudo apt-get purge -y -f firefox \
+                                   google-chrome-stable \
+                                   microsoft-edge-stable
+          sudo apt-get autoremove -y >& /dev/null
+          sudo apt-get autoclean -y >& /dev/null
+          sudo docker image prune --all --force
+          df -h
+      
+      - name: "Install CUDA Toolkit on Linux (if needed)"
+        uses: Jimver/cuda-toolkit@v0.2.10
+        with:
+          cuda: ${{ matrix.cuda-version }}
+          linux-local-args: '["--toolkit", "--override"]'
+        if: startsWith(matrix.os, 'ubuntu')
+
+      - name: "Install SDK on MacOS (if needed)"
+        run: source devtools/scripts/install_macos_sdk.sh
+        if: startsWith(matrix.os, 'macos')
+
+      - name: "Update the conda enviroment file"
+        uses: cschleiden/replace-tokens@v1
+        with:
+          tokenPrefix: '@'
+          tokenSuffix: '@'
+          files: devtools/conda-envs/build-${{ matrix.os }}.yml
+        env:
+          CUDATOOLKIT_VERSION: ${{ matrix.cuda-version }}
+          GCC_VERSION: ${{ matrix.gcc-version }}
+          NVCC_VERSION: ${{ matrix.nvcc-version }}
+          PYTORCH_VERSION: ${{ matrix.pytorch-version }}
+
       - uses: conda-incubator/setup-miniconda@v2
         name: "Install dependencies with Mamba"
         with:

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,7 +2,7 @@
 # OpenMM PyTorch Plugin
 #----------------------------------------------------
 
-CMAKE_MINIMUM_REQUIRED(VERSION 3.5)
+CMAKE_MINIMUM_REQUIRED(VERSION 3.7)
 
 # We need to know where OpenMM is installed so we can access the headers and libraries.
 SET(OPENMM_DIR "/usr/local/openmm" CACHE PATH "Where OpenMM is installed")
@@ -14,8 +14,15 @@ SET(PYTORCH_DIR "" CACHE PATH "Where the PyTorch C++ API is installed")
 SET(CMAKE_PREFIX_PATH "${PYTORCH_DIR}")
 FIND_PACKAGE(Torch REQUIRED)
 
-# Specify the C++ version we are building for.
-SET (CMAKE_CXX_STANDARD 14)
+# Specify the C++ version we are building for. Latest pytorch versions require C++17
+message(STATUS "Found Torch: ${Torch_VERSION}")
+if(${Torch_VERSION} VERSION_GREATER_EQUAL "2.1.0")
+    set(CMAKE_CXX_STANDARD 17)
+    message(STATUS "Setting C++ standard to C++17")
+else()
+    set(CMAKE_CXX_STANDARD 14)
+    message(STATUS "Setting C++ standard to C++14")
+endif()
 
 # Set flags for linking on mac
 IF(APPLE)

--- a/devtools/conda-envs/build-ubuntu-22.04.yml
+++ b/devtools/conda-envs/build-ubuntu-22.04.yml
@@ -18,3 +18,6 @@ dependencies:
   - swig
   - sysroot_linux-64 2.17
   - torchani
+  # Required by python<3.8
+  # xref: https://github.com/conda-forge/linux-sysroot-feedstock/issues/52
+  - libxcrypt

--- a/openmmapi/include/TorchForce.h
+++ b/openmmapi/include/TorchForce.h
@@ -129,6 +129,13 @@ public:
      */
     const std::string& getEnergyParameterDerivativeName(int index) const;
     /**
+     * Get the number of global parameters with respect to which the derivative of the energy
+     * should be computed.
+     */
+    int getNumEnergyParameterDerivatives() const {
+        return energyParameterDerivatives.size();
+    }
+    /**
      * Get the name of a global parameter.
      *
      * @param index     the index of the parameter for which to get the name

--- a/openmmapi/include/TorchForce.h
+++ b/openmmapi/include/TorchForce.h
@@ -58,8 +58,7 @@ public:
      * @param file       the path to the file containing the network
      * @param properties optional map of properties
      */
-    TorchForce(const std::string& file,
-               const std::map<std::string, std::string>& properties = {});
+    TorchForce(const std::string& file, const std::map<std::string, std::string>& properties = {});
     /**
      * Create a TorchForce.  The network is defined by a PyTorch ScriptModule
      * Note that this constructor makes a copy of the provided module.
@@ -68,7 +67,7 @@ public:
      * @param module   an instance of the torch module
      * @param properties optional map of properties
      */
-    TorchForce(const torch::jit::Module &module, const std::map<std::string, std::string>& properties = {});
+    TorchForce(const torch::jit::Module& module, const std::map<std::string, std::string>& properties = {});
     /**
      * Get the path to the file containing the network.
      * If the TorchForce instance was constructed with a module, instead of a filename,
@@ -78,7 +77,7 @@ public:
     /**
      * Get the torch module currently in use.
      */
-    const torch::jit::Module & getModule() const;
+    const torch::jit::Module& getModule() const;
     /**
      * Set whether this force makes use of periodic boundary conditions.  If this is set
      * to true, the network must take a 3x3 tensor as its second input, which
@@ -116,6 +115,19 @@ public:
      * @return the index of the parameter that was added
      */
     int addGlobalParameter(const std::string& name, double defaultValue);
+    /**
+     * Add a new energy parameter derivative that the interaction may depend on.
+     *
+     * @param name             the name of the parameter
+     */
+    void addEnergyParameterDerivative(const std::string& name);
+    /**
+     * Get the name of an energy parameter derivative given its global parameter index.
+     *
+     * @param index     the index of the parameter for which to get the name
+     * @return the parameter name
+     */
+    const std::string& getEnergyParameterDerivativeName(int index) const;
     /**
      * Get the name of a global parameter.
      *
@@ -156,13 +168,16 @@ public:
      * @return A map of property names to values.
      */
     const std::map<std::string, std::string>& getProperties() const;
+
 protected:
     OpenMM::ForceImpl* createImpl() const;
+
 private:
     class GlobalParameterInfo;
     std::string file;
     bool usePeriodic, outputsForces;
     std::vector<GlobalParameterInfo> globalParameters;
+    std::vector<std::string> energyParameterDerivatives;
     torch::jit::Module module;
     std::map<std::string, std::string> properties;
     std::string emptyProperty;

--- a/openmmapi/include/TorchForce.h
+++ b/openmmapi/include/TorchForce.h
@@ -177,7 +177,7 @@ private:
     std::string file;
     bool usePeriodic, outputsForces;
     std::vector<GlobalParameterInfo> globalParameters;
-    std::vector<std::string> energyParameterDerivatives;
+    std::vector<int> energyParameterDerivatives;
     torch::jit::Module module;
     std::map<std::string, std::string> properties;
     std::string emptyProperty;

--- a/openmmapi/src/TorchForce.cpp
+++ b/openmmapi/src/TorchForce.cpp
@@ -88,6 +88,21 @@ int TorchForce::addGlobalParameter(const string& name, double defaultValue) {
     return globalParameters.size() - 1;
 }
 
+void TorchForce::addEnergyParameterDerivative(const string& name) {
+    for (int i = 0; i < globalParameters.size(); i++) {
+        if (globalParameters[i].name == name) {
+            energyParameterDerivatives.push_back(i);
+            return;
+        }
+    }
+}
+
+const std::string& TorchForce::getEnergyParameterDerivativeName(int index) const {
+    if (index < 0 || index >= energyParameterDerivatives.size())
+        throw OpenMM::OpenMMException("TorchForce::getEnergyParameterDerivativeName: index out of range.");
+    return globalParameters[energyParameterDerivatives[index]].name;
+}
+
 int TorchForce::getNumGlobalParameters() const {
     return globalParameters.size();
 }

--- a/platforms/cuda/src/CudaTorchKernels.cpp
+++ b/platforms/cuda/src/CudaTorchKernels.cpp
@@ -52,9 +52,7 @@ using namespace std;
     }
 
 static map<string, double>& extractEnergyParameterDerivatives(CudaContext& context) {
-  //CudaPlatform::PlatformData* data = reinterpret_cast<CudaPlatform::PlatformData*>(context.getPlatformData());
-  //return *data->energyParameterDerivatives;
-  context.getEnergyParamDerivWorkspace();
+    return context.getEnergyParamDerivWorkspace();
 }
 
 CudaCalcTorchForceKernel::CudaCalcTorchForceKernel(string name, const Platform& platform, CudaContext& cu) : CalcTorchForceKernel(name, platform), hasInitializedKernel(false), cu(cu) {

--- a/platforms/cuda/src/CudaTorchKernels.cpp
+++ b/platforms/cuda/src/CudaTorchKernels.cpp
@@ -70,8 +70,10 @@ void CudaCalcTorchForceKernel::initialize(const System& system, const TorchForce
     outputsForces = force.getOutputsForces();
     for (int i = 0; i < force.getNumGlobalParameters(); i++)
         globalNames.push_back(force.getGlobalParameterName(i));
-    for (int i = 0; i < force.getNumEnergyParameterDerivatives(); i++)
-        energyParameterDerivatives.push_back(force.getEnergyParameterDerivativeName(i));
+    for (int i = 0; i < force.getNumEnergyParameterDerivatives(); i++){
+        auto name = force.getEnergyParameterDerivativeName(i);
+        energyParameterDerivatives.push_back(name);
+	cu.addEnergyParameterDerivative(name);
     int numParticles = system.getNumParticles();
 
     // Push the PyTorch context

--- a/platforms/cuda/src/CudaTorchKernels.cpp
+++ b/platforms/cuda/src/CudaTorchKernels.cpp
@@ -159,11 +159,8 @@ std::vector<torch::jit::IValue> CudaCalcTorchForceKernel::prepareTorchInputs(Con
         bool requires_grad = std::find(energyParameterDerivatives.begin(), energyParameterDerivatives.end(), name) != energyParameterDerivatives.end();
         auto options = torch::TensorOptions().requires_grad(requires_grad).device(posTensor.device());
         auto tensor = torch::tensor(context.getParameter(name), options);
-        // parameterTensors.emplace_back(tensor);
         inputs.push_back(tensor);
     }
-    // for (const string& name : globalNames)
-    //     inputs.push_back(torch::tensor(context.getParameter(name)));
     return inputs;
 }
 

--- a/platforms/cuda/src/CudaTorchKernels.h
+++ b/platforms/cuda/src/CudaTorchKernels.h
@@ -71,6 +71,7 @@ private:
     torch::jit::script::Module module;
     torch::Tensor posTensor, boxTensor;
     torch::Tensor energyTensor, forceTensor;
+    std::vector<torch::Tensor> gradientTensors;
     std::vector<std::string> globalNames;
     std::vector<std::string> energyParameterDerivatives;
     bool usePeriodic, outputsForces;

--- a/platforms/cuda/src/CudaTorchKernels.h
+++ b/platforms/cuda/src/CudaTorchKernels.h
@@ -72,6 +72,7 @@ private:
     torch::Tensor posTensor, boxTensor;
     torch::Tensor energyTensor, forceTensor;
     std::vector<std::string> globalNames;
+    std::vector<std::string> energyParameterDerivatives;
     bool usePeriodic, outputsForces;
     CUfunction copyInputsKernel, addForcesKernel;
     CUcontext primaryContext;

--- a/platforms/opencl/src/OpenCLTorchKernels.cpp
+++ b/platforms/opencl/src/OpenCLTorchKernels.cpp
@@ -51,6 +51,9 @@ void OpenCLCalcTorchForceKernel::initialize(const System& system, const TorchFor
     outputsForces = force.getOutputsForces();
     for (int i = 0; i < force.getNumGlobalParameters(); i++)
         globalNames.push_back(force.getGlobalParameterName(i));
+    for (int i = 0; i < force.getNumEnergyParameterDerivatives(); i++)
+        energyParameterDerivatives.push_back(force.getEnergyParameterDerivativeName(i));
+
     int numParticles = system.getNumParticles();
 
     // Inititalize OpenCL objects.

--- a/platforms/opencl/src/OpenCLTorchKernels.h
+++ b/platforms/opencl/src/OpenCLTorchKernels.h
@@ -49,7 +49,7 @@ public:
     ~OpenCLCalcTorchForceKernel();
     /**
      * Initialize the kernel.
-     * 
+     *
      * @param system         the System this kernel will be applied to
      * @param force          the TorchForce this kernel will be used for
      * @param module         the PyTorch module to use for computing forces and energy
@@ -69,6 +69,7 @@ private:
     OpenMM::OpenCLContext& cl;
     torch::jit::script::Module module;
     std::vector<std::string> globalNames;
+    std::vector<std::string> energyParameterDerivatives;
     bool usePeriodic, outputsForces;
     OpenMM::OpenCLArray networkForces;
     cl::Kernel addForcesKernel;

--- a/platforms/reference/src/ReferenceTorchKernels.h
+++ b/platforms/reference/src/ReferenceTorchKernels.h
@@ -48,7 +48,7 @@ public:
     ~ReferenceCalcTorchForceKernel();
     /**
      * Initialize the kernel.
-     * 
+     *
      * @param system         the System this kernel will be applied to
      * @param force          the TorchForce this kernel will be used for
      * @param module         the PyTorch module to use for computing forces and energy
@@ -67,6 +67,7 @@ private:
     torch::jit::script::Module module;
     std::vector<float> positions, boxVectors;
     std::vector<std::string> globalNames;
+    std::vector<std::string> energyParameterDerivatives;
     bool usePeriodic, outputsForces;
 };
 

--- a/python/CMakeLists.txt
+++ b/python/CMakeLists.txt
@@ -23,6 +23,7 @@ add_custom_command(
 add_custom_target(PythonInstall DEPENDS "${WRAP_FILE}"  "${CMAKE_CURRENT_SOURCE_DIR}/setup.py")
 set(NN_PLUGIN_HEADER_DIR "${CMAKE_SOURCE_DIR}/openmmapi/include")
 set(NN_PLUGIN_LIBRARY_DIR "${CMAKE_BINARY_DIR}")
+set(EXTENSION_CXX_STANDARD "${CMAKE_CXX_STANDARD}")
 configure_file(${CMAKE_CURRENT_SOURCE_DIR}/setup.py ${CMAKE_CURRENT_BINARY_DIR}/setup.py)
 add_custom_command(TARGET PythonInstall
     COMMAND "${PYTHON_EXECUTABLE}" -m pip install .

--- a/python/openmmtorch.i
+++ b/python/openmmtorch.i
@@ -74,6 +74,8 @@ public:
     void setGlobalParameterName(int index, const std::string& name);
     double getGlobalParameterDefaultValue(int index) const;
     void setGlobalParameterDefaultValue(int index, double defaultValue);
+    void addEnergyParameterDerivative(const std::string& name);
+    const std::string& getEnergyParameterDerivativeName(int index) const;
     void setProperty(const std::string& name, const std::string& value);
     const std::map<std::string, std::string>& getProperties() const;
 

--- a/python/setup.py
+++ b/python/setup.py
@@ -6,10 +6,11 @@ openmm_dir = '@OPENMM_DIR@'
 torch_include_dirs = '@TORCH_INCLUDE_DIRS@'.split(';')
 nn_plugin_header_dir = '@NN_PLUGIN_HEADER_DIR@'
 nn_plugin_library_dir = '@NN_PLUGIN_LIBRARY_DIR@'
+cpp_std = '@EXTENSION_CXX_STANDARD@'
 torch_dir, _ = os.path.split('@TORCH_LIBRARY@')
 
 # setup extra compile and link arguments on Mac
-extra_compile_args = ['-std=c++14']
+extra_compile_args = ['-std=c++' + cpp_std]
 extra_link_args = []
 
 if platform.system() == 'Darwin':

--- a/python/tests/TestParameterDerivatives.py
+++ b/python/tests/TestParameterDerivatives.py
@@ -40,7 +40,7 @@ def testParameterEnergyDerivatives(use_cv_force, platform):
     parameter = 1.0
     force.addGlobalParameter("parameter", parameter)
     # Enable energy derivatives for the parameter
-    force.setEnergyParameterDerivatives("parameter")
+    force.addEnergyParameterDerivatives("parameter")
     force.setOutputsForces(True)
     if use_cv_force:
         # Wrap TorchForce into CustomCVForce

--- a/python/tests/TestParameterDerivatives.py
+++ b/python/tests/TestParameterDerivatives.py
@@ -40,7 +40,7 @@ def testParameterEnergyDerivatives(use_cv_force, platform):
     parameter = 1.0
     force.addGlobalParameter("parameter", parameter)
     # Enable energy derivatives for the parameter
-    force.addEnergyParameterDerivatives("parameter")
+    force.addEnergyParameterDerivative("parameter")
     force.setOutputsForces(True)
     if use_cv_force:
         # Wrap TorchForce into CustomCVForce

--- a/python/tests/TestParameterDerivatives.py
+++ b/python/tests/TestParameterDerivatives.py
@@ -82,8 +82,9 @@ def testParameterEnergyDerivatives(
     parameter2 = 1.0
     tforce.setOutputsForces(return_forces)
     tforce.addGlobalParameter("parameter1", parameter1)
-    tforce.addEnergyParameterDerivative("parameter1")
     tforce.addGlobalParameter("parameter2", parameter2)
+    # Enable energy derivatives for the parameters
+    tforce.addEnergyParameterDerivative("parameter1")
     tforce.addEnergyParameterDerivative("parameter2")
     if use_cv_force:
         # Wrap TorchForce into CustomCVForce
@@ -91,7 +92,6 @@ def testParameterEnergyDerivatives(
         force.addCollectiveVariable("force", tforce)
     else:
         force = tforce
-    # Enable energy derivatives for the parameter
     system.addForce(force)
     # Compute the forces and energy.
     integ = mm.VerletIntegrator(1.0)

--- a/python/tests/TestParameterDerivatives.py
+++ b/python/tests/TestParameterDerivatives.py
@@ -18,7 +18,7 @@ class ForceWithParameters(pt.nn.Module):
         return u_harmonic
 
 
-@pytest.mark.parametrize("use_cv_force", [True, False])
+@pytest.mark.parametrize("use_cv_force", [False, True])
 @pytest.mark.parametrize("platform", ["Reference", "CPU", "CUDA", "OpenCL"])
 def testParameterEnergyDerivatives(use_cv_force, platform):
 
@@ -41,7 +41,7 @@ def testParameterEnergyDerivatives(use_cv_force, platform):
     force.addGlobalParameter("parameter", parameter)
     # Enable energy derivatives for the parameter
     force.addEnergyParameterDerivative("parameter")
-    force.setOutputsForces(True)
+    force.setOutputsForces(False)
     if use_cv_force:
         # Wrap TorchForce into CustomCVForce
         cv_force = mm.CustomCVForce("force")
@@ -56,7 +56,7 @@ def testParameterEnergyDerivatives(use_cv_force, platform):
     context = mm.Context(system, integ, platform)
     context.setPositions(positions)
     state = context.getState(
-        getEnergy=True, getForces=True, getEnergyParameterDerivatives=True
+        getEnergy=True, getForces=True, getParameterDerivatives=True
     )
 
     # See if the energy and forces and the parameter derivative are correct.
@@ -69,8 +69,6 @@ def testParameterEnergyDerivatives(use_cv_force, platform):
     )
     assert np.allclose(-2 * parameter * positions, state.getForces(asNumpy=True))
     assert np.allclose(
-        2 * r2,
-        state.getEnergyParameterDerivatives()["parameter"].value_in_unit(
-            unit.kilojoules_per_mole
-        ),
+        r2,
+        state.getEnergyParameterDerivatives()["parameter"],
     )

--- a/python/tests/TestParameterDerivatives.py
+++ b/python/tests/TestParameterDerivatives.py
@@ -41,6 +41,7 @@ class EnergyForceWithParameters(pt.nn.Module):
                 [positions],
                 grad_outputs=grad_outputs,
                 create_graph=False,
+                # This must be true, otherwise pytorch will not allow to compute the gradients with respect to the parameters
                 retain_graph=True,
             )[0]
             assert dy is not None

--- a/python/tests/TestParameterDerivatives.py
+++ b/python/tests/TestParameterDerivatives.py
@@ -1,0 +1,76 @@
+import openmm as mm
+import openmm.unit as unit
+import openmmtorch as ot
+import numpy as np
+import pytest
+import torch as pt
+from torch import Tensor
+
+
+class ForceWithParameters(pt.nn.Module):
+
+    def __init__(self):
+        super(ForceWithParameters, self).__init__()
+
+    def forward(self, positions: Tensor, parameter: Tensor) -> Tensor:
+        x2 = positions.pow(2).sum(dim=1)
+        u_harmonic = (parameter * x2).sum()
+        return u_harmonic
+
+
+@pytest.mark.parametrize("use_cv_force", [True, False])
+@pytest.mark.parametrize("platform", ["Reference", "CPU", "CUDA", "OpenCL"])
+def testParameterEnergyDerivatives(use_cv_force, platform):
+
+    if pt.cuda.device_count() < 1 and platform == "CUDA":
+        pytest.skip("A CUDA device is not available")
+
+    # Create a random cloud of particles.
+    numParticles = 10
+    system = mm.System()
+    positions = np.random.rand(numParticles, 3)
+    for _ in range(numParticles):
+        system.addParticle(1.0)
+
+    # Create a force
+    pt_force = ForceWithParameters()
+    model = pt.jit.script(pt_force)
+    force = ot.TorchForce(model, {"useCUDAGraphs": "false"})
+    # Add a parameter
+    parameter = 1.0
+    force.addGlobalParameter("parameter", parameter)
+    # Enable energy derivatives for the parameter
+    force.setEnergyParameterDerivatives("parameter")
+    force.setOutputsForces(True)
+    if use_cv_force:
+        # Wrap TorchForce into CustomCVForce
+        cv_force = mm.CustomCVForce("force")
+        cv_force.addCollectiveVariable("force", force)
+        system.addForce(cv_force)
+    else:
+        system.addForce(force)
+
+    # Compute the forces and energy.
+    integ = mm.VerletIntegrator(1.0)
+    platform = mm.Platform.getPlatformByName(platform)
+    context = mm.Context(system, integ, platform)
+    context.setPositions(positions)
+    state = context.getState(
+        getEnergy=True, getForces=True, getEnergyParameterDerivatives=True
+    )
+
+    # See if the energy and forces and the parameter derivative are correct.
+    # The network defines a potential of the form E(r) = parameter*|r|^2
+    r2 = np.sum(positions * positions)
+    expectedEnergy = parameter * r2
+    assert np.allclose(
+        expectedEnergy,
+        state.getPotentialEnergy().value_in_unit(unit.kilojoules_per_mole),
+    )
+    assert np.allclose(-2 * parameter * positions, state.getForces(asNumpy=True))
+    assert np.allclose(
+        2 * r2,
+        state.getEnergyParameterDerivatives()["parameter"].value_in_unit(
+            unit.kilojoules_per_mole
+        ),
+    )


### PR DESCRIPTION
Allows to get energy derivatives with respect to global parameters in TorchForce as in the following example:
```python
class ForceWithParameters(pt.nn.Module):

    def __init__(self):
        super(ForceWithParameters, self).__init__()

    def forward(
        self, positions: Tensor, parameter1: Tensor, parameter2: Tensor
    ) -> Tensor:
        x2 = positions.pow(2).sum(dim=1)
        u_harmonic = ((parameter1 + parameter2**2) * x2).sum()
        return u_harmonic


def example():
    # Create a random cloud of particles.
    numParticles = 10
    system = mm.System()
    positions = np.random.rand(numParticles, 3)
    for _ in range(numParticles):
        system.addParticle(1.0)

    # Create a force
    pt_force = ForceWithParameters()
    model = pt.jit.script(pt_force)
    tforce = ot.TorchForce(model)
    # Add some parameters
    parameter1 = 1.0
    parameter2 = 1.0
    force.setOutputsForces(False)
    force.addGlobalParameter("parameter1", parameter1)
    force.addEnergyParameterDerivative("parameter1")
    force.addGlobalParameter("parameter2", parameter2)
    force.addEnergyParameterDerivative("parameter2")
    # Enable energy derivatives for the parameter
    system.addForce(force)
    # Compute the forces and energy.
    integ = mm.VerletIntegrator(1.0)
    platform = mm.Platform.getPlatformByName(platform)
    context = mm.Context(system, integ, platform)
    context.setPositions(positions)
    state = context.getState(
        getEnergy=True, getForces=True, getParameterDerivatives=True
    )
    # See if the energy and forces and the parameter derivative are correct.
    # The network defines a potential of the form E(r) = (parameter1 + parameter2**2)*|r|^2
    r2 = np.sum(positions * positions)
    expectedEnergy = (parameter1 + parameter2**2) * r2
    assert np.allclose(
        r2,
        state.getEnergyParameterDerivatives()["parameter1"],
    )
    assert np.allclose(
        2 * parameter2 * r2,
        state.getEnergyParameterDerivatives()["parameter2"],
    )

```

Closes #140
Closes #141 