### PR TITLE
Freeze pytorch model

### DIFF
--- a/platforms/cuda/src/CudaTorchKernels.cpp
+++ b/platforms/cuda/src/CudaTorchKernels.cpp
@@ -79,7 +79,9 @@ void CudaCalcTorchForceKernel::initialize(const System& system, const TorchForce
 
     // Initialize CUDA objects for PyTorch
     const torch::Device device(torch::kCUDA, cu.getDeviceIndex()); // This implicitly initialize PyTorch
-    module.to(device);
+    this->module.to(device);
+    this->module.eval();
+    this->module = torch::jit::freeze(this->module);
     torch::TensorOptions options = torch::TensorOptions().device(device).dtype(cu.getUseDoublePrecision() ? torch::kFloat64 : torch::kFloat32);
     posTensor = torch::empty({numParticles, 3}, options.requires_grad(!outputsForces));
     boxTensor = torch::empty({3, 3}, options);

--- a/platforms/opencl/src/OpenCLTorchKernels.cpp
+++ b/platforms/opencl/src/OpenCLTorchKernels.cpp
@@ -55,6 +55,8 @@ void OpenCLCalcTorchForceKernel::initialize(const System& system, const TorchFor
 
     // Inititalize OpenCL objects.
 
+    this->module.eval();
+    this->module = torch::jit::freeze(this->module);
     map<string, string> defines;
     if (cl.getUseDoublePrecision()) {
         networkForces.initialize<double>(cl, 3*numParticles, "networkForces");

--- a/platforms/reference/src/ReferenceTorchKernels.cpp
+++ b/platforms/reference/src/ReferenceTorchKernels.cpp
@@ -64,6 +64,8 @@ ReferenceCalcTorchForceKernel::~ReferenceCalcTorchForceKernel() {
 
 void ReferenceCalcTorchForceKernel::initialize(const System& system, const TorchForce& force, torch::jit::script::Module& module) {
     this->module = module;
+    this->module.eval();
+    this->module = torch::jit::freeze(this->module);
     usePeriodic = force.usesPeriodicBoundaryConditions();
     outputsForces = force.getOutputsForces();
     for (int i = 0; i < force.getNumGlobalParameters(); i++)


### PR DESCRIPTION
Freezing the model allows PyTorch to do more optimizations on it.  I ran some tests on the Nutmeg models, and found typical speedups of about 2 to 7%.  Not huge, but worth doing.

There's another function called `optimize_for_inference()` that can do even more optimizations.  But the documentation says it's still in prototype and can sometimes slow models down.  For the moment, it seems best to stick to just freezing.

