### PR TITLE
Add pytorch lib dir to rpath

### DIFF
--- a/python/setup.py
+++ b/python/setup.py
@@ -14,14 +14,14 @@ extra_link_args = []
 
 if platform.system() == 'Darwin':
     extra_compile_args += ['-stdlib=libc++', '-mmacosx-version-min=10.13']
-    extra_link_args += ['-stdlib=libc++', '-mmacosx-version-min=10.13', '-Wl', '-rpath', openmm_dir+'/lib', '-rpath', torch_dir]
+    extra_link_args += ['-stdlib=libc++', '-mmacosx-version-min=10.13']
 
 extension = Extension(name='_openmmtorch',
                       sources=['TorchPluginWrapper.cpp'],
                       libraries=['OpenMM', 'OpenMMTorch'],
                       include_dirs=[os.path.join(openmm_dir, 'include'), nn_plugin_header_dir] + torch_include_dirs,
                       library_dirs=[os.path.join(openmm_dir, 'lib'), nn_plugin_library_dir],
-                      runtime_library_dirs=[os.path.join(openmm_dir, 'lib')],
+                      runtime_library_dirs=[os.path.join(openmm_dir, 'lib'), torch_dir],
                       extra_compile_args=extra_compile_args,
                       extra_link_args=extra_link_args
                      )


### PR DESCRIPTION
It was only getting added on Mac, not on Linux.